### PR TITLE
refactor(cargo): remove unused features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ node = ["napi", "napi-derive", "napi-build"]
 chrono = { version = "0.4", features = ["wasmbind"] }
 js-sys = "0.3"
 serde-wasm-bindgen = "0.4"
-wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
+wasm-bindgen = { version = "0.2.83" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 chrono = "0.4"


### PR DESCRIPTION
This PR removes `serde-serialize` from wasm-bindgen: 

For the context, it is depreacted https://github.com/rustwasm/wasm-bindgen/pull/3031 and it is one of the culprit causes tricky circular dependency issue https://github.com/tkaitchuck/aHash/issues/95.

Alternative recommendation is to use `serde-wasm-bindgen`, which seems already being used and looks like `serde-serialize` is not being used anyway.