### PR TITLE
Move wasm-bindgen behind a feature flag

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,4 +62,4 @@ jobs:
         with:
           submodules: true
       - run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-      - run: wasm-pack build --dev --target=web
+      - run: wasm-pack build --dev --target=web -- --features wasm_bindgen

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,12 +45,12 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 string_cache_codegen = "0.5.2"
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-chrono = { version = "0.4.23", features = ["wasmbind"] }
-getrandom = { version = "0.2", features = ["js"] }
-js-sys = "0.3"
-serde-wasm-bindgen = "0.4"
-wasm-bindgen = { version = "0.2" }
+# [target.'cfg(target_arch = "wasm32")'.dependencies]
+# chrono = { version = "0.4.23", features = ["wasmbind"] }
+# getrandom = { version = "0.2", features = ["js"] }
+# js-sys = "0.3"
+# serde-wasm-bindgen = "0.4"
+# wasm-bindgen = { version = "0.2" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 chrono = "0.4.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,12 @@ include = [
 name = "browserslist"
 crate-type = ["cdylib", "rlib"]
 
+[features]
+wasm-bindgen = ["chrono/wasmbind", "getrandom/js"]
+
 [dependencies]
 ahash = { version = "0.8", features = ["serde"] }
+chrono = { version = "0.4.23", features = ["std", "clock", "oldtime"], default-features = false } # disable wasmbind by default
 either = "1.8"
 itertools = "0.10"
 nom = "7.1"
@@ -45,15 +49,13 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 string_cache_codegen = "0.5.2"
 
-# [target.'cfg(target_arch = "wasm32")'.dependencies]
-# chrono = { version = "0.4.23", features = ["wasmbind"] }
-# getrandom = { version = "0.2", features = ["js"] }
-# js-sys = "0.3"
-# serde-wasm-bindgen = "0.4"
-# wasm-bindgen = { version = "0.2" }
+[target.'cfg(all(feature = "wasm-bindgen", target_arch = "wasm32"))'.dependencies]
+getrandom = "0.2"
+js-sys = "0.3"
+serde-wasm-bindgen = "0.4"
+wasm-bindgen = { version = "0.2" }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-chrono = "0.4.23"
+[target.'cfg(any(not(feature = "wasm-bindgen"), not(target_arch = "wasm32")))'.dependencies]
 
 [[bench]]
 name = "resolve"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ name = "browserslist"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-wasm-bindgen = ["chrono/wasmbind", "getrandom/js"]
+wasm_bindgen = ["chrono/wasmbind", "getrandom", "getrandom/js", "js-sys", "serde-wasm-bindgen", "wasm-bindgen"]
 
 [dependencies]
 ahash = { version = "0.8", features = ["serde"] }
@@ -49,13 +49,11 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 string_cache_codegen = "0.5.2"
 
-[target.'cfg(all(feature = "wasm-bindgen", target_arch = "wasm32"))'.dependencies]
-getrandom = "0.2"
-js-sys = "0.3"
-serde-wasm-bindgen = "0.4"
-wasm-bindgen = { version = "0.2" }
-
-[target.'cfg(any(not(feature = "wasm-bindgen"), not(target_arch = "wasm32")))'.dependencies]
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", optional = true }
+js-sys = { version = "0.3", optional = true }
+serde-wasm-bindgen = { version = "0.4", optional = true }
+wasm-bindgen = { version = "0.2", optional = true }
 
 [[bench]]
 name = "resolve"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,8 +60,8 @@
 
 use parser::parse_browserslist_query;
 use std::cmp::Ordering;
-// #[cfg(target_arch = "wasm32")]
-// pub use wasm::browserslist;
+#[cfg(all(feature = "wasm-bindgen", target_arch = "wasm32"))]
+pub use wasm::browserslist;
 pub use {error::Error, opts::Opts, queries::Distrib};
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -74,8 +74,8 @@ mod queries;
 mod semver;
 #[cfg(test)]
 mod test;
-// #[cfg(target_arch = "wasm32")]
-// mod wasm;
+#[cfg(all(feature = "wasm-bindgen", target_arch = "wasm32"))]
+mod wasm;
 
 /// Resolve browserslist queries.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@
 
 use parser::parse_browserslist_query;
 use std::cmp::Ordering;
-#[cfg(all(feature = "wasm-bindgen", target_arch = "wasm32"))]
+#[cfg(all(feature = "wasm_bindgen", target_arch = "wasm32"))]
 pub use wasm::browserslist;
 pub use {error::Error, opts::Opts, queries::Distrib};
 
@@ -74,7 +74,7 @@ mod queries;
 mod semver;
 #[cfg(test)]
 mod test;
-#[cfg(all(feature = "wasm-bindgen", target_arch = "wasm32"))]
+#[cfg(all(feature = "wasm_bindgen", target_arch = "wasm32"))]
 mod wasm;
 
 /// Resolve browserslist queries.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,8 +74,8 @@ mod queries;
 mod semver;
 #[cfg(test)]
 mod test;
-#[cfg(target_arch = "wasm32")]
-mod wasm;
+// #[cfg(target_arch = "wasm32")]
+// mod wasm;
 
 /// Resolve browserslist queries.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,8 +60,8 @@
 
 use parser::parse_browserslist_query;
 use std::cmp::Ordering;
-#[cfg(target_arch = "wasm32")]
-pub use wasm::browserslist;
+// #[cfg(target_arch = "wasm32")]
+// pub use wasm::browserslist;
 pub use {error::Error, opts::Opts, queries::Distrib};
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/src/queries/current_node.rs
+++ b/src/queries/current_node.rs
@@ -4,7 +4,7 @@ use crate::error::Error;
 pub(super) fn current_node() -> QueryResult {
     #[cfg(target_arch = "wasm32")]
     {
-        #[cfg(feature = "wasm-bindgen")]
+        #[cfg(feature = "wasm_bindgen")]
         {
             use js_sys::{global, Reflect};
 

--- a/src/queries/current_node.rs
+++ b/src/queries/current_node.rs
@@ -4,17 +4,22 @@ use crate::error::Error;
 pub(super) fn current_node() -> QueryResult {
     #[cfg(target_arch = "wasm32")]
     {
-        use js_sys::{global, Reflect};
+        #[cfg(feature = "wasm-bindgen")]
+        {
+            use js_sys::{global, Reflect};
 
-        let obj_process = Reflect::get(&global(), &"process".into())
-            .map_err(|_| Error::UnsupportedCurrentNode)?;
-        let obj_versions = Reflect::get(&obj_process, &"versions".into())
-            .map_err(|_| Error::UnsupportedCurrentNode)?;
-        let version = Reflect::get(&obj_versions, &"node".into())
-            .map_err(|_| Error::UnsupportedCurrentNode)?
-            .as_string()
-            .ok_or(Error::UnsupportedCurrentNode)?;
-        Ok(vec![Distrib::new("node", version)])
+            let obj_process = Reflect::get(&global(), &"process".into())
+                .map_err(|_| Error::UnsupportedCurrentNode)?;
+            let obj_versions = Reflect::get(&obj_process, &"versions".into())
+                .map_err(|_| Error::UnsupportedCurrentNode)?;
+            let version = Reflect::get(&obj_versions, &"node".into())
+                .map_err(|_| Error::UnsupportedCurrentNode)?
+                .as_string()
+                .ok_or(Error::UnsupportedCurrentNode)?;
+            return Ok(vec![Distrib::new("node", version)]);
+        }
+
+        Err(Error::UnsupportedCurrentNode)
     }
 
     #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
This adds a `wasm_bindgen` feature flag and moves all related dependencies behind it. This is useful so that projects that depend on browserslist-rs can compile for WASM, even when not using wasm-bindgen. wasm-bindgen imposes some additional requirements on the wasm environment, such as some imports. If those aren't provided loading the wasm fails.