### PR TITLE
Make vendor data completely static

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ chrono = { version = "0.4.38", features = [
     "oldtime",
 ], default-features = false } # disable wasmbind by default
 either = "1.13"
-indexmap = { version = "2.6", features = ["serde"] }
 itertools = "0.13"
 nom = "7.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/generate-data/Cargo.toml
+++ b/generate-data/Cargo.toml
@@ -11,3 +11,4 @@ indexmap = { version = "2.6", features = ["serde"] }
 quote = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+chrono = { version = "0.4" }

--- a/generate-data/src/main.rs
+++ b/generate-data/src/main.rs
@@ -38,13 +38,13 @@ fn encode_browser_name(name: &str) -> u8 {
 
 #[derive(Deserialize)]
 struct Caniuse {
-    agents: HashMap<String, Agent>,
+    agents: BTreeMap<String, Agent>,
     data: BTreeMap<String, Feature>,
 }
 
 #[derive(Deserialize)]
 struct Agent {
-    usage_global: HashMap<String, f32>,
+    usage_global: BTreeMap<String, f32>,
     version_list: Vec<VersionDetail>,
 }
 
@@ -57,7 +57,7 @@ struct VersionDetail {
 
 #[derive(Deserialize)]
 struct Feature {
-    stats: HashMap<String, IndexMap<String, String>>,
+    stats: BTreeMap<String, IndexMap<String, String>>,
 }
 
 fn main() -> Result<()> {
@@ -127,7 +127,7 @@ fn build_node_release_schedule() -> Result<()> {
 
     let path = format!("{OUT_DIR}/node-release-schedule.rs");
 
-    let schedule: HashMap<String, NodeRelease> = serde_json::from_slice(&fs::read(
+    let schedule: BTreeMap<String, NodeRelease> = serde_json::from_slice(&fs::read(
         "vendor/node-releases/data/release-schedule/release-schedule.json",
     )?)?;
     let mut versions = schedule
@@ -386,7 +386,7 @@ fn build_caniuse() -> Result<()> {
     {
         #[derive(Deserialize)]
         struct RegionData {
-            data: HashMap<String, HashMap<String, Option<f32>>>,
+            data: BTreeMap<String, BTreeMap<String, Option<f32>>>,
         }
 
         let files = fs::read_dir("vendor/caniuse/region-usage-json")?

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "license": "MIT",
   "repository": "https://github.com/browserslist/browserslist-rs",
   "devDependencies": {
-    "browserslist": "^4.24.4"
+    "browserslist": "^4.25.0"
   }
 }

--- a/src/data/caniuse.rs
+++ b/src/data/caniuse.rs
@@ -6,7 +6,7 @@ use std::{borrow::Cow, sync::LazyLock};
 pub(crate) mod features;
 pub(crate) mod region;
 
-use crate::data::BinaryMap;
+use crate::data::utils::BinMap;
 
 pub const ANDROID_EVERGREEN_FIRST: f32 = 37.0;
 pub const OP_MOB_BLINK_FIRST: u32 = 14;
@@ -28,7 +28,7 @@ pub struct VersionDetail {
 
 include!("../generated/caniuse-browsers.rs");
 
-pub static CANIUSE_BROWSERS: BinaryMap<PooledStr, BrowserStat> = BinaryMap(BROWSERS_STATS);
+pub static CANIUSE_BROWSERS: BinMap<PooledStr, BrowserStat> = BinMap(BROWSERS_STATS);
 
 pub static CANIUSE_GLOBAL_USAGE: &[(PooledStr, PooledStr, f32)] =
     include!("../generated/caniuse-global-usage.rs");
@@ -227,8 +227,10 @@ impl BrowserStat {
 
 impl PooledStr {
     pub fn as_str(&self) -> &'static str {
+        static STRPOOL: &'static str = include_str!("../generated/caniuse-strpool.bin");
+
         let range = (self.0 as usize)..(self.1 as usize);
-        &CANIUSE_STRPOOL[range]
+        &STRPOOL[range]
     }
 }
 

--- a/src/data/caniuse.rs
+++ b/src/data/caniuse.rs
@@ -15,7 +15,7 @@ pub const OP_MOB_BLINK_FIRST: u32 = 14;
 pub struct BrowserStat(u32, u32);
 
 #[derive(Clone, Copy)]
-pub struct PooledStr(u32, u32);
+pub struct PooledStr(u32);
 
 #[derive(Clone, Debug)]
 pub struct VersionDetail {
@@ -229,8 +229,11 @@ impl PooledStr {
     pub fn as_str(&self) -> &'static str {
         static STRPOOL: &'static str = include_str!("../generated/caniuse-strpool.bin");
 
-        let range = (self.0 as usize)..(self.1 as usize);
-        &STRPOOL[range]
+        // 24bit offset and 8bit len
+        let offset = self.0 & ((1 << 24) - 1);
+        let len = self.0 >> 24;
+
+        &STRPOOL[(offset as usize)..][..(len as usize)]
     }
 }
 

--- a/src/data/caniuse.rs
+++ b/src/data/caniuse.rs
@@ -1,7 +1,9 @@
 use ahash::AHashMap;
-use std::borrow::Borrow;
-use std::fmt;
-use std::{borrow::Cow, sync::LazyLock};
+use std::{
+    borrow::{Borrow, Cow},
+    fmt,
+    sync::LazyLock,
+};
 
 pub(crate) mod features;
 pub(crate) mod region;
@@ -227,7 +229,7 @@ impl BrowserStat {
 
 impl PooledStr {
     pub fn as_str(&self) -> &'static str {
-        static STRPOOL: &'static str = include_str!("../generated/caniuse-strpool.bin");
+        static STRPOOL: &str = include_str!("../generated/caniuse-strpool.bin");
 
         // 24bit offset and 8bit len
         let offset = self.0 & ((1 << 24) - 1);

--- a/src/data/caniuse.rs
+++ b/src/data/caniuse.rs
@@ -1,31 +1,36 @@
 use ahash::AHashMap;
+use std::borrow::Borrow;
+use std::fmt;
 use std::{borrow::Cow, sync::LazyLock};
 
 pub(crate) mod features;
 pub(crate) mod region;
 
+use crate::data::BinaryMap;
+
 pub const ANDROID_EVERGREEN_FIRST: f32 = 37.0;
 pub const OP_MOB_BLINK_FIRST: u32 = 14;
 
 #[derive(Clone, Debug)]
-pub struct BrowserStat {
-    name: &'static str,
-    pub version_list: Vec<VersionDetail>,
-}
+pub struct BrowserStat(u32, u32);
+
+#[derive(Clone, Copy)]
+pub struct PooledStr(u32, u32);
 
 #[derive(Clone, Debug)]
 pub struct VersionDetail {
-    pub version: &'static str,
+    pub version: PooledStr,
+    pub release_date: i64,
+    // Use bool instead of Option to use pad space
+    pub released: bool,
     pub global_usage: f32,
-    pub release_date: Option<i64>,
 }
 
-pub type CaniuseData = AHashMap<&'static str, BrowserStat>;
+include!("../generated/caniuse-browsers.rs");
 
-pub static CANIUSE_BROWSERS: LazyLock<CaniuseData> =
-    LazyLock::new(|| include!("../generated/caniuse-browsers.rs"));
+pub static CANIUSE_BROWSERS: BinaryMap<PooledStr, BrowserStat> = BinaryMap(BROWSERS_STATS);
 
-pub static CANIUSE_GLOBAL_USAGE: &[(&'static str, &'static str, f32)] =
+pub static CANIUSE_GLOBAL_USAGE: &[(PooledStr, PooledStr, f32)] =
     include!("../generated/caniuse-global-usage.rs");
 
 pub static BROWSER_VERSION_ALIASES: LazyLock<
@@ -34,27 +39,29 @@ pub static BROWSER_VERSION_ALIASES: LazyLock<
     let mut aliases = CANIUSE_BROWSERS
         .iter()
         .filter_map(|(name, stat)| {
+            let name = name.as_str();
             let aliases = stat
-                .version_list
+                .version_list()
                 .iter()
                 .filter_map(|version| {
                     version
                         .version
+                        .as_str()
                         .split_once('-')
                         .map(|(bottom, top)| (bottom, top, version.version))
                 })
                 .fold(
                     AHashMap::<&str, &str>::new(),
                     move |mut aliases, (bottom, top, version)| {
-                        let _ = aliases.insert(bottom, version);
-                        let _ = aliases.insert(top, version);
+                        let _ = aliases.insert(bottom, version.as_str());
+                        let _ = aliases.insert(top, version.as_str());
                         aliases
                     },
                 );
             if aliases.is_empty() {
                 None
             } else {
-                Some((*name, aliases))
+                Some((name, aliases))
             }
         })
         .collect::<AHashMap<&'static str, _>>();
@@ -66,49 +73,37 @@ pub static BROWSER_VERSION_ALIASES: LazyLock<
     aliases
 });
 
-static ANDROID_TO_DESKTOP: LazyLock<BrowserStat> = LazyLock::new(|| {
+static ANDROID_TO_DESKTOP: LazyLock<Vec<VersionDetail>> = LazyLock::new(|| {
     let chrome = CANIUSE_BROWSERS.get("chrome").unwrap();
-    let mut android = CANIUSE_BROWSERS.get("android").unwrap().clone();
+    let android = CANIUSE_BROWSERS.get("android").unwrap();
 
-    android.version_list = android
-        .version_list
-        .into_iter()
+    let chrome_point = chrome
+        .version_list()
+        .binary_search_by_key(&(ANDROID_EVERGREEN_FIRST as usize), |probe| {
+            probe.version.as_str().parse::<usize>().unwrap()
+        })
+        .unwrap();
+
+    android
+        .version_list()
+        .iter()
         .filter(|version| {
-            let version = version.version;
+            let version = version.version.as_str();
             version.starts_with("2.")
                 || version.starts_with("3.")
                 || version.starts_with("4.")
                 || version == "3"
                 || version == "4"
         })
-        .chain(
-            chrome
-                .version_list
-                .iter()
-                .skip(
-                    chrome
-                        .version_list
-                        .iter()
-                        .position(|version| {
-                            version.version.parse::<usize>().unwrap()
-                                == ANDROID_EVERGREEN_FIRST as usize
-                        })
-                        .unwrap(),
-                )
-                .cloned(),
-        )
-        .collect();
-
-    android
+        .chain(chrome.version_list().iter().skip(chrome_point))
+        .cloned()
+        .collect()
 });
-
-static OPERA_MOBILE_TO_DESKTOP: LazyLock<BrowserStat> =
-    LazyLock::new(|| CANIUSE_BROWSERS.get("opera").unwrap().clone());
 
 pub fn get_browser_stat(
     name: &str,
     mobile_to_desktop: bool,
-) -> Option<(&'static str, &'static BrowserStat)> {
+) -> Option<(&'static str, &'static [VersionDetail])> {
     let name = if name.bytes().all(|b| b.is_ascii_lowercase()) {
         Cow::from(name)
     } else {
@@ -119,18 +114,53 @@ pub fn get_browser_stat(
     if mobile_to_desktop {
         if let Some(desktop_name) = to_desktop_name(name) {
             match name {
-                "android" => Some(("android", &ANDROID_TO_DESKTOP)),
-                "op_mob" => Some(("op_mob", &OPERA_MOBILE_TO_DESKTOP)),
-                _ => CANIUSE_BROWSERS
-                    .get(desktop_name)
-                    .map(|stat| (get_mobile_by_desktop_name(desktop_name), stat)),
+                "android" => Some(("android", &*ANDROID_TO_DESKTOP)),
+                "op_mob" => {
+                    let stat = CANIUSE_BROWSERS.get("opera").unwrap();
+                    Some(("op_mob", stat.version_list()))
+                }
+                _ => CANIUSE_BROWSERS.get(desktop_name).map(|stat| {
+                    (
+                        get_mobile_by_desktop_name(desktop_name),
+                        stat.version_list(),
+                    )
+                }),
             }
         } else {
-            CANIUSE_BROWSERS.get(name).map(|stat| (stat.name, stat))
+            CANIUSE_BROWSERS
+                .get_key_value(name)
+                .map(|(k, v)| (k.as_str(), v.version_list()))
         }
     } else {
-        CANIUSE_BROWSERS.get(name).map(|stat| (stat.name, stat))
+        CANIUSE_BROWSERS
+            .get_key_value(name)
+            .map(|(k, v)| (k.as_str(), v.version_list()))
     }
+}
+
+pub fn iter_browser_stat(
+    mobile_to_desktop: bool,
+) -> impl Iterator<Item = (&'static str, &'static [VersionDetail])> {
+    CANIUSE_BROWSERS.iter().filter_map(move |(name, stat)| {
+        match (
+            mobile_to_desktop,
+            to_desktop_name(name.as_str()),
+            name.as_str(),
+        ) {
+            (false, _, _) | (true, None, _) => Some((name.as_str(), stat.version_list())),
+            (true, Some(_), "android") => Some(("android", &*ANDROID_TO_DESKTOP)),
+            (true, Some(_), "op_mob") => {
+                let stat = CANIUSE_BROWSERS.get("opera").unwrap();
+                Some(("op_mob", stat.version_list()))
+            }
+            (true, Some(desktop_name), _) => CANIUSE_BROWSERS.get(desktop_name).map(|stat| {
+                (
+                    get_mobile_by_desktop_name(desktop_name),
+                    stat.version_list(),
+                )
+            }),
+        }
+    })
 }
 
 fn get_browser_alias(name: &str) -> &str {
@@ -170,19 +200,52 @@ fn get_mobile_by_desktop_name(name: &str) -> &'static str {
 }
 
 pub(crate) fn normalize_version<'a>(
-    stat: &'static BrowserStat,
+    name: &'a str,
+    version_list: &'static [VersionDetail],
     version: &'a str,
 ) -> Option<&'a str> {
-    if stat.version_list.iter().any(|v| v.version == version) {
+    if version_list.iter().any(|v| v.version.as_str() == version) {
         Some(version)
     } else if let Some(version) = BROWSER_VERSION_ALIASES
-        .get(&stat.name)
+        .get(name)
         .and_then(|aliases| aliases.get(version))
     {
         Some(version)
-    } else if stat.version_list.len() == 1 {
-        stat.version_list.first().map(|s| s.version)
+    } else if version_list.len() == 1 {
+        version_list.first().map(|s| s.version.as_str())
     } else {
         None
+    }
+}
+
+impl BrowserStat {
+    pub fn version_list(&self) -> &'static [VersionDetail] {
+        let range = (self.0 as usize)..(self.1 as usize);
+        &VERSION_LIST[range]
+    }
+}
+
+impl PooledStr {
+    pub fn as_str(&self) -> &'static str {
+        let range = (self.0 as usize)..(self.1 as usize);
+        &CANIUSE_STRPOOL[range]
+    }
+}
+
+impl Borrow<str> for PooledStr {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for PooledStr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl fmt::Debug for PooledStr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
     }
 }

--- a/src/data/caniuse/features.rs
+++ b/src/data/caniuse/features.rs
@@ -1,6 +1,8 @@
-use super::{ BinMap, PooledStr };
-use crate::data::decode_browser_name;
-use crate::data::utils::{ PairU32, U32 };
+use super::PooledStr;
+use crate::data::{
+    decode_browser_name,
+    utils::{BinMap, PairU32, U32},
+};
 
 #[derive(Clone, Copy)]
 pub struct Feature(u32, u32);
@@ -26,13 +28,11 @@ pub(crate) fn get_feature_stat(name: &str) -> Option<Feature> {
 impl Feature {
     pub fn get(&self, browser: &str) -> Option<VersionList> {
         let range = (self.0 as usize)..(self.1 as usize);
-        let index = FEATURES_STAT_BROWSERS[range.clone()].binary_search_by_key(
-            &browser,
-            |&k| decode_browser_name(k)
-        )
+        let index = FEATURES_STAT_BROWSERS[range.clone()]
+            .binary_search_by_key(&browser, |&k| decode_browser_name(k))
             .ok()?;
-        let pair = FEATURES_STAT_VERSION_INDEX[range.clone()][index];
-        Some(VersionList(pair))
+        let list = FEATURES_STAT_VERSION_INDEX[range][index];
+        Some(VersionList(list))
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (&'static str, VersionList)> {
@@ -46,7 +46,7 @@ impl Feature {
 
 impl VersionList {
     pub fn get(&self, version: &str) -> Option<u8> {
-        let range = (self.0.0.get() as usize)..(self.0.1.get() as usize);
+        let range = (self.0 .0.get() as usize)..(self.0 .1.get() as usize);
         let index = FEATURES_STAT_VERSION_STORE[range.clone()]
             .binary_search_by_key(&version, |s| PooledStr(s.get()).as_str())
             .ok()?;

--- a/src/data/caniuse/features.rs
+++ b/src/data/caniuse/features.rs
@@ -1,6 +1,6 @@
 use super::{ BinMap, PooledStr };
 use crate::data::decode_browser_name;
-use crate::data::utils::PairU32;
+use crate::data::utils::{ PairU32, U32 };
 
 #[derive(Clone, Copy)]
 pub struct Feature(u32, u32);
@@ -42,7 +42,7 @@ impl VersionList {
     pub fn get(&self, version: &str) -> Option<u8> {
         let range = (self.0.0.get() as usize)..(self.0.1.get() as usize);
         let index = FEATURES_STAT_VERSION_STORE[range.clone()]
-            .binary_search_by_key(&version, |s| PooledStr(s.0.get(), s.1.get()).as_str())
+            .binary_search_by_key(&version, |s| PooledStr(s.get()).as_str())
             .ok()?;
         Some(FEATURES_STAT_FLAGS[range][index])
     }

--- a/src/data/caniuse/features.rs
+++ b/src/data/caniuse/features.rs
@@ -8,10 +8,16 @@ pub struct Feature(u32, u32);
 #[derive(Clone, Copy)]
 pub struct VersionList(PairU32);
 
+// ```rust
+// static FEATURES: &[(PooledStr, Feature)]; // feature name and browsers list
+//
+// static FEATURES_STAT_VERSION_STORE: &[U32]; // version string
+// static FEATURES_STAT_VERSION_INDEX: &[PairU32]; // version range
+//
+// static FEATURES_STAT_FLAGS: &[u8]; // support flag
+// static FEATURES_STAT_BROWSERS: &[u8]; // browser name id
+// ```
 include!("../../generated/caniuse-feature-matching.rs");
-
-static FEATURES_STAT_FLAGS: &[u8] = include_bytes!("../../generated/caniuse-feature-flags.bin");
-static FEATURES_STAT_BROWSERS: &[u8] = include_bytes!("../../generated/caniuse-feature-browsers.bin");
 
 pub(crate) fn get_feature_stat(name: &str) -> Option<Feature> {
     BinMap(FEATURES).get(name).copied()

--- a/src/data/caniuse/features.rs
+++ b/src/data/caniuse/features.rs
@@ -1,8 +1,49 @@
-use ahash::AHashMap;
-use indexmap::IndexMap;
+use super::{ BinMap, PooledStr };
+use crate::data::decode_browser_name;
+use crate::data::utils::PairU32;
 
-type Feature = AHashMap<&'static str, IndexMap<&'static str, u8>>;
+#[derive(Clone, Copy)]
+pub struct Feature(u32, u32);
 
-pub(crate) fn get_feature_stat(name: &str) -> Option<&'static Feature> {
-    include!("../../generated/caniuse-feature-matching.rs")
+#[derive(Clone, Copy)]
+pub struct VersionList(PairU32);
+
+include!("../../generated/caniuse-feature-matching.rs");
+
+static FEATURES_STAT_FLAGS: &[u8] = include_bytes!("../../generated/caniuse-feature-flags.bin");
+static FEATURES_STAT_BROWSERS: &[u8] = include_bytes!("../../generated/caniuse-feature-browsers.bin");
+
+pub(crate) fn get_feature_stat(name: &str) -> Option<Feature> {
+    BinMap(FEATURES).get(name).copied()
+}
+
+impl Feature {
+    pub fn get(&self, browser: &str) -> Option<VersionList> {
+        let range = (self.0 as usize)..(self.1 as usize);
+        let index = FEATURES_STAT_BROWSERS[range.clone()].binary_search_by_key(
+            &browser,
+            |&k| decode_browser_name(k)
+        )
+            .ok()?;
+        let pair = FEATURES_STAT_VERSION_INDEX[range.clone()][index];
+        Some(VersionList(pair))
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&'static str, VersionList)> {
+        let range = (self.0 as usize)..(self.1 as usize);
+        FEATURES_STAT_BROWSERS[range.clone()]
+            .iter()
+            .zip(&FEATURES_STAT_VERSION_INDEX[range])
+            .map(|(&name, &list)| (decode_browser_name(name), VersionList(list)))
+    }
+}
+
+impl VersionList {
+    pub fn get(&self, version: &str) -> Option<u8> {
+        let range = (self.0.0.get() as usize)..(self.0.1.get() as usize);
+        let index = FEATURES_STAT_VERSION_STORE[range.clone()]
+            .binary_search_by_key(&version, |s| PooledStr(s.0.get(), s.1.get()).as_str())
+            .ok()?;
+        Some(FEATURES_STAT_FLAGS[range][index])
+    }
 }

--- a/src/data/caniuse/region.rs
+++ b/src/data/caniuse/region.rs
@@ -1,16 +1,18 @@
 use super::PooledStr;
-use crate::data::decode_browser_name;
-use crate::data::utils::{ U32, BinMap };
+use crate::data::{
+    decode_browser_name,
+    utils::{BinMap, U32},
+};
 
 #[derive(Clone, Copy)]
-pub struct RegionData(u32 ,u32);
+pub struct RegionData(u32, u32);
 
 // ```rust
 // static REGIONS: &[(PooledStr, RegionData)]; // region name and region data
 //
-// static REGIONS_BROWSERS: &[u8]; browser name id
-// static REGIONS_VERSIONS: &[U32]; version string
-// static REGIONS_USAGES: &[U32]; browser usage (f32)
+// static REGIONS_BROWSERS: &[u8]; // browser name id
+// static REGIONS_VERSIONS: &[U32]; // version string
+// static REGIONS_USAGES: &[U32]; // browser usage (f32)
 // ```
 include!("../../generated/caniuse-region-matching.rs");
 
@@ -19,18 +21,19 @@ pub(crate) fn get_usage_by_region(region: &str) -> Option<RegionData> {
 }
 
 impl RegionData {
-    pub fn iter(&self)-> impl Iterator<Item = (&'static str, &'static str, f32)>
-    {
+    pub fn iter(&self) -> impl Iterator<Item = (&'static str, &'static str, f32)> {
         let range = (self.0 as usize)..(self.1 as usize);
 
         REGIONS_BROWSERS[range.clone()]
             .iter()
             .zip(&REGIONS_VERSIONS[range.clone()])
             .zip(&REGIONS_USAGES[range])
-            .map(|((browser, version), usage)| (
-                decode_browser_name(*browser),
-                PooledStr(version.get()).as_str(),
-                f32::from_bits(usage.get())
-            ))
+            .map(|((browser, version), usage)| {
+                (
+                    decode_browser_name(*browser),
+                    PooledStr(version.get()).as_str(),
+                    f32::from_bits(usage.get()),
+                )
+            })
     }
 }

--- a/src/data/caniuse/region.rs
+++ b/src/data/caniuse/region.rs
@@ -1,5 +1,36 @@
-type RegionData = Vec<(&'static str, &'static str, f32)>;
+use super::PooledStr;
+use crate::data::decode_browser_name;
+use crate::data::utils::{ U32, BinMap };
 
-pub(crate) fn get_usage_by_region(region: &str) -> Option<&'static RegionData> {
-    include!("../../generated/caniuse-region-matching.rs")
+#[derive(Clone, Copy)]
+pub struct RegionData(u32 ,u32);
+
+// ```rust
+// static REGIONS: &[(PooledStr, RegionData)]; // region name and region data
+//
+// static REGIONS_BROWSERS: &[u8]; browser name id
+// static REGIONS_VERSIONS: &[U32]; version string
+// static REGIONS_USAGES: &[U32]; browser usage (f32)
+// ```
+include!("../../generated/caniuse-region-matching.rs");
+
+pub(crate) fn get_usage_by_region(region: &str) -> Option<RegionData> {
+    BinMap(REGIONS).get(region).copied()
+}
+
+impl RegionData {
+    pub fn iter(&self)-> impl Iterator<Item = (&'static str, &'static str, f32)>
+    {
+        let range = (self.0 as usize)..(self.1 as usize);
+
+        REGIONS_BROWSERS[range.clone()]
+            .iter()
+            .zip(&REGIONS_VERSIONS[range.clone()])
+            .zip(&REGIONS_USAGES[range])
+            .map(|((browser, version), usage)| (
+                decode_browser_name(*browser),
+                PooledStr(version.get()).as_str(),
+                f32::from_bits(usage.get())
+            ))
+    }
 }

--- a/src/data/electron.rs
+++ b/src/data/electron.rs
@@ -5,10 +5,35 @@ use nom::{
     number::complete::float,
     sequence::{pair, terminated},
 };
-use std::sync::LazyLock;
+use std::ops::Range;
 
-pub static ELECTRON_VERSIONS: LazyLock<Vec<(f32, &'static str)>> =
-    LazyLock::new(|| include!("../generated/electron-to-chromium.rs"));
+include!("../generated/electron-to-chromium.rs");
+
+pub fn versions(
+) -> impl Iterator<Item = (f32, &'static str)> + ExactSizeIterator + DoubleEndedIterator {
+    ELECTRON_VERSIONS
+        .iter()
+        .copied()
+        .zip(CHROMIUM_VERSIONS.iter().copied())
+}
+
+pub fn get(electron_version: f32) -> Option<&'static str> {
+    let index = ELECTRON_VERSIONS
+        .binary_search_by(|probe| probe.total_cmp(&electron_version))
+        .ok()?;
+    CHROMIUM_VERSIONS.get(index).copied()
+}
+
+pub fn bounded_range(range: Range<f32>) -> Result<&'static [&'static str], f32> {
+    let start = ELECTRON_VERSIONS
+        .binary_search_by(|probe| probe.total_cmp(&range.start))
+        .map_err(|_| range.start)?;
+    let end = ELECTRON_VERSIONS
+        .binary_search_by(|probe| probe.total_cmp(&range.end))
+        .map_err(|_| range.end)?;
+
+    Ok(&CHROMIUM_VERSIONS[start..=end])
+}
 
 pub(crate) fn parse_version(version: &str) -> Result<f32, Error> {
     all_consuming(terminated(float, opt(pair(char('.'), u16))))(version)

--- a/src/data/electron.rs
+++ b/src/data/electron.rs
@@ -9,8 +9,7 @@ use std::ops::Range;
 
 include!("../generated/electron-to-chromium.rs");
 
-pub fn versions(
-) -> impl Iterator<Item = (f32, &'static str)> + ExactSizeIterator + DoubleEndedIterator {
+pub fn versions() -> impl ExactSizeIterator<Item = (f32, &'static str)> + DoubleEndedIterator {
     ELECTRON_VERSIONS
         .iter()
         .copied()

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,7 +1,7 @@
-mod utils;
 pub(crate) mod caniuse;
 pub(crate) mod electron;
 pub(crate) mod node;
+mod utils;
 
 #[doc(hidden)]
 pub fn decode_browser_name(id: u8) -> &'static str {

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,5 +1,4 @@
-use std::borrow::Borrow;
-
+mod utils;
 pub(crate) mod caniuse;
 pub(crate) mod electron;
 pub(crate) mod node;
@@ -27,31 +26,5 @@ pub fn decode_browser_name(id: u8) -> &'static str {
         18 => "baidu",
         19 => "kaios",
         _ => unreachable!("cannot recognize browser id"),
-    }
-}
-
-pub struct BinaryMap<'a, K, V>(&'a [(K, V)]);
-
-impl<K, V> BinaryMap<'_, K, V> {
-    pub fn get<Q>(&self, q: &Q) -> Option<&V>
-    where
-        K: Borrow<Q>,
-        Q: Ord + ?Sized,
-    {
-        self.get_key_value(q).map(|(_, v)| v)
-    }
-
-    pub fn get_key_value<Q>(&self, q: &Q) -> Option<(&K, &V)>
-    where
-        K: Borrow<Q>,
-        Q: Ord + ?Sized,
-    {
-        let idx = self.0.binary_search_by(|(k, _)| k.borrow().cmp(&q)).ok()?;
-        let item = &self.0[idx];
-        Some((&item.0, &item.1))
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = &(K, V)> {
-        self.0.iter()
     }
 }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,3 +1,5 @@
+use std::borrow::Borrow;
+
 pub(crate) mod caniuse;
 pub(crate) mod electron;
 pub(crate) mod node;
@@ -25,5 +27,31 @@ pub fn decode_browser_name(id: u8) -> &'static str {
         18 => "baidu",
         19 => "kaios",
         _ => unreachable!("cannot recognize browser id"),
+    }
+}
+
+pub struct BinaryMap<'a, K, V>(&'a [(K, V)]);
+
+impl<K, V> BinaryMap<'_, K, V> {
+    pub fn get<Q>(&self, q: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        self.get_key_value(q).map(|(_, v)| v)
+    }
+
+    pub fn get_key_value<Q>(&self, q: &Q) -> Option<(&K, &V)>
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        let idx = self.0.binary_search_by(|(k, _)| k.borrow().cmp(&q)).ok()?;
+        let item = &self.0[idx];
+        Some((&item.0, &item.1))
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &(K, V)> {
+        self.0.iter()
     }
 }

--- a/src/data/utils.rs
+++ b/src/data/utils.rs
@@ -1,0 +1,45 @@
+use std::borrow::Borrow;
+
+pub struct BinMap<'a, K, V>(pub(super) &'a [(K, V)]);
+
+impl<K, V> BinMap<'_, K, V> {
+    pub fn get<Q>(&self, q: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        self.get_key_value(q).map(|(_, v)| v)
+    }
+
+    pub fn get_key_value<Q>(&self, q: &Q) -> Option<(&K, &V)>
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        let idx = self.0.binary_search_by(|(k, _)| k.borrow().cmp(&q)).ok()?;
+        let item = &self.0[idx];
+        Some((&item.0, &item.1))
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &(K, V)>
+        + ExactSizeIterator
+        + DoubleEndedIterator
+    {
+        self.0.iter()
+    }
+}
+
+// We define repr C instead of using tuple to ensure a stable memory layout.
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub(super) struct PairU32(pub U32, pub U32);
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub(super) struct U32(u32);
+
+impl U32 {
+    pub const fn get(self) -> u32 {
+        self.0.to_le()
+    }
+}

--- a/src/data/utils.rs
+++ b/src/data/utils.rs
@@ -16,15 +16,15 @@ impl<K, V> BinMap<'_, K, V> {
         K: Borrow<Q>,
         Q: Ord + ?Sized,
     {
-        let idx = self.0.binary_search_by(|(k, _)| k.borrow().cmp(&q)).ok()?;
+        let idx = self
+            .0
+            .binary_search_by(|(k, _)| Ord::cmp(k.borrow(), q))
+            .ok()?;
         let item = &self.0[idx];
         Some((&item.0, &item.1))
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &(K, V)>
-        + ExactSizeIterator
-        + DoubleEndedIterator
-    {
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &(K, V)> + DoubleEndedIterator {
         self.0.iter()
     }
 }

--- a/src/queries/browser_accurate.rs
+++ b/src/queries/browser_accurate.rs
@@ -19,6 +19,7 @@ pub(super) fn browser_accurate(name: &str, version: &str, opts: &Opts) -> QueryR
         .ok_or_else(|| Error::BrowserNotFound(name.to_string()))?;
 
     if let Some(version) = normalize_version(
+        name,
         stat,
         if original_version.eq_ignore_ascii_case("tp") {
             "TP"
@@ -35,7 +36,7 @@ pub(super) fn browser_accurate(name: &str, version: &str, opts: &Opts) -> QueryR
             v.push_str(".0");
             Cow::Owned(v)
         };
-        if let Some(version) = normalize_version(stat, &version) {
+        if let Some(version) = normalize_version(name, stat, &version) {
             Ok(vec![Distrib::new(name, version.to_owned())])
         } else if opts.ignore_unknown_versions {
             Ok(vec![])

--- a/src/queries/browser_bounded_range.rs
+++ b/src/queries/browser_bounded_range.rs
@@ -9,25 +9,24 @@ use crate::{
 pub(super) fn browser_bounded_range(name: &str, from: &str, to: &str, opts: &Opts) -> QueryResult {
     let (name, stat) = get_browser_stat(name, opts.mobile_to_desktop)
         .ok_or_else(|| Error::BrowserNotFound(name.to_string()))?;
-    let from: Version = normalize_version(stat, from)
+    let from: Version = normalize_version(name, stat, from)
         .unwrap_or(from)
         .parse()
         .unwrap_or_default();
-    let to: Version = normalize_version(stat, to)
+    let to: Version = normalize_version(name, stat, to)
         .unwrap_or(to)
         .parse()
         .unwrap_or_default();
 
     let distribs = stat
-        .version_list
         .iter()
-        .filter(|version| version.release_date.is_some())
+        .filter(|version| version.released)
         .map(|version| version.version)
         .filter(|version| {
-            let version = version.parse().unwrap_or_default();
+            let version = version.as_str().parse().unwrap_or_default();
             from <= version && version <= to
         })
-        .map(|version| Distrib::new(name, version))
+        .map(|version| Distrib::new(name, version.as_str()))
         .collect();
     Ok(distribs)
 }

--- a/src/queries/browser_unbounded_range.rs
+++ b/src/queries/browser_unbounded_range.rs
@@ -23,10 +23,9 @@ pub(super) fn browser_unbounded_range(
         .unwrap_or_default();
 
     let distribs = stat
-        .version_list
         .iter()
-        .filter(|version| version.release_date.is_some())
-        .map(|version| version.version)
+        .filter(|version| version.released)
+        .map(|version| version.version.as_str())
         .filter(|v| {
             let v: Version = v.parse().unwrap_or_default();
             match comparator {

--- a/src/queries/cover.rs
+++ b/src/queries/cover.rs
@@ -9,7 +9,7 @@ pub(super) fn cover(coverage: f32) -> QueryResult {
             if total >= coverage || *usage == 0.0 {
                 ControlFlow::Break((distribs, total))
             } else {
-                distribs.push(Distrib::new(name, *version));
+                distribs.push(Distrib::new(name.as_str(), version.as_str()));
                 ControlFlow::Continue((distribs, total + usage))
             }
         },

--- a/src/queries/cover_by_region.rs
+++ b/src/queries/cover_by_region.rs
@@ -13,10 +13,10 @@ pub(super) fn cover_by_region(coverage: f32, region: &str) -> QueryResult {
         let result = region_data.iter().try_fold(
             (vec![], 0.0),
             |(mut distribs, total), (name, version, usage)| {
-                if total >= coverage || *usage == 0.0 {
+                if total >= coverage || usage == 0.0 {
                     ControlFlow::Break((distribs, total))
                 } else {
-                    distribs.push(Distrib::new(name, *version));
+                    distribs.push(Distrib::new(name, version));
                     ControlFlow::Continue((distribs, total + usage))
                 }
             },

--- a/src/queries/electron_accurate.rs
+++ b/src/queries/electron_accurate.rs
@@ -1,6 +1,6 @@
 use super::{Distrib, QueryResult};
 use crate::{
-    data::electron::{parse_version, ELECTRON_VERSIONS},
+    data::electron::{self, parse_version},
     error::Error,
 };
 
@@ -8,10 +8,8 @@ pub(super) fn electron_accurate(version: &str) -> QueryResult {
     let version_str = version;
     let version: f32 = parse_version(version)?;
 
-    let distribs = ELECTRON_VERSIONS
-        .iter()
-        .find(|(electron_version, _)| *electron_version == version)
-        .map(|(_, chromium_version)| vec![Distrib::new("chrome", *chromium_version)])
+    let distribs = electron::get(version)
+        .map(|chromium_version| vec![Distrib::new("chrome", chromium_version)])
         .ok_or_else(|| Error::UnknownElectronVersion(version_str.to_string()))?;
     Ok(distribs)
 }

--- a/src/queries/electron_unbounded_range.rs
+++ b/src/queries/electron_unbounded_range.rs
@@ -1,21 +1,20 @@
 use super::{Distrib, QueryResult};
 use crate::{
-    data::electron::{parse_version, ELECTRON_VERSIONS},
+    data::electron::{self, parse_version},
     parser::Comparator,
 };
 
 pub(super) fn electron_unbounded_range(comparator: Comparator, version: &str) -> QueryResult {
     let version: f32 = parse_version(version)?;
 
-    let distribs = ELECTRON_VERSIONS
-        .iter()
+    let distribs = electron::versions()
         .filter(|(electron_version, _)| match comparator {
             Comparator::Greater => *electron_version > version,
             Comparator::Less => *electron_version < version,
             Comparator::GreaterOrEqual => *electron_version >= version,
             Comparator::LessOrEqual => *electron_version <= version,
         })
-        .map(|(_, chromium_version)| Distrib::new("chrome", *chromium_version))
+        .map(|(_, chromium_version)| Distrib::new("chrome", chromium_version))
         .collect();
     Ok(distribs)
 }

--- a/src/queries/extends.rs
+++ b/src/queries/extends.rs
@@ -46,8 +46,8 @@ fn check_extend_name(pkg: &str) -> Result<(), Error> {
         .strip_prefix('@')
         .and_then(|s| s.find('/').and_then(|i| s.get(i + 1..)))
         .unwrap_or(pkg);
-    if !unscoped.starts_with("browserslist-config-")
-        && !(pkg.starts_with('@') && unscoped == "browserslist-config")
+    if !(unscoped.starts_with("browserslist-config-")
+        || (pkg.starts_with('@') && unscoped == "browserslist-config"))
     {
         return Err(Error::InvalidExtendName(
             "Browserslist config needs `browserslist-config-` prefix.",

--- a/src/queries/last_n_browsers.rs
+++ b/src/queries/last_n_browsers.rs
@@ -1,22 +1,17 @@
 use super::{count_filter_versions, Distrib, QueryResult};
-use crate::{
-    data::caniuse::{get_browser_stat, CANIUSE_BROWSERS},
-    opts::Opts,
-};
+use crate::{data::caniuse, opts::Opts};
 
 pub(super) fn last_n_browsers(count: usize, opts: &Opts) -> QueryResult {
-    let distribs = CANIUSE_BROWSERS
-        .keys()
-        .filter_map(|name| get_browser_stat(name, opts.mobile_to_desktop))
-        .flat_map(|(name, stat)| {
+    let distribs = caniuse::iter_browser_stat(opts.mobile_to_desktop)
+        .flat_map(|(name, version_list)| {
             let count = count_filter_versions(name, opts.mobile_to_desktop, count);
 
-            stat.version_list
+            version_list
                 .iter()
-                .filter(|version| version.release_date.is_some())
+                .filter(|version| version.released)
                 .rev()
                 .take(count)
-                .map(move |version| Distrib::new(name, version.version))
+                .map(move |version| Distrib::new(name, version.version.as_str()))
         })
         .collect();
 

--- a/src/queries/last_n_electron.rs
+++ b/src/queries/last_n_electron.rs
@@ -1,12 +1,11 @@
 use super::{Distrib, QueryResult};
-use crate::data::electron::ELECTRON_VERSIONS;
+use crate::data::electron;
 
 pub(super) fn last_n_electron(count: usize) -> QueryResult {
-    let distribs = ELECTRON_VERSIONS
-        .iter()
+    let distribs = electron::versions()
         .rev()
         .take(count)
-        .map(|(_, version)| Distrib::new("chrome", *version))
+        .map(|(_, version)| Distrib::new("chrome", version))
         .collect();
     Ok(distribs)
 }

--- a/src/queries/last_n_electron_major.rs
+++ b/src/queries/last_n_electron_major.rs
@@ -1,21 +1,19 @@
 use super::{Distrib, QueryResult};
-use crate::data::electron::ELECTRON_VERSIONS;
+use crate::data::electron;
 use itertools::Itertools;
 
 pub(super) fn last_n_electron_major(count: usize) -> QueryResult {
-    let minimum = ELECTRON_VERSIONS
-        .iter()
+    let minimum = electron::versions()
         .rev()
         .dedup()
         .nth(count - 1)
         .map(|(electron_version, _)| electron_version)
-        .unwrap_or(&0.0);
+        .unwrap_or(0.0);
 
-    let distribs = ELECTRON_VERSIONS
-        .iter()
-        .filter(|(electron_version, _)| electron_version >= minimum)
+    let distribs = electron::versions()
+        .filter(|(electron_version, _)| *electron_version >= minimum)
         .rev()
-        .map(|(_, chromium_version)| Distrib::new("chrome", *chromium_version))
+        .map(|(_, chromium_version)| Distrib::new("chrome", chromium_version))
         .collect();
 
     Ok(distribs)

--- a/src/queries/last_n_node.rs
+++ b/src/queries/last_n_node.rs
@@ -1,8 +1,8 @@
 use super::{Distrib, QueryResult};
-use crate::data::node::NODE_VERSIONS;
+use crate::data::node;
 
 pub(super) fn last_n_node(count: usize) -> QueryResult {
-    let distribs = NODE_VERSIONS
+    let distribs = node::versions()
         .iter()
         .rev()
         .take(count)

--- a/src/queries/last_n_node_major.rs
+++ b/src/queries/last_n_node_major.rs
@@ -1,9 +1,9 @@
 use super::{Distrib, QueryResult};
-use crate::{data::node::NODE_VERSIONS, semver::Version};
+use crate::{data::node, semver::Version};
 use itertools::Itertools;
 
 pub(super) fn last_n_node_major(count: usize) -> QueryResult {
-    let minimum = NODE_VERSIONS
+    let minimum = node::versions()
         .iter()
         .rev()
         .map(|version| {
@@ -16,7 +16,7 @@ pub(super) fn last_n_node_major(count: usize) -> QueryResult {
         .nth(count - 1)
         .unwrap_or_default();
 
-    let distribs = NODE_VERSIONS
+    let distribs = node::versions()
         .iter()
         .filter(|version| {
             version

--- a/src/queries/last_n_x_browsers.rs
+++ b/src/queries/last_n_x_browsers.rs
@@ -2,17 +2,16 @@ use super::{count_filter_versions, Distrib, QueryResult};
 use crate::{data::caniuse::get_browser_stat, error::Error, opts::Opts};
 
 pub(super) fn last_n_x_browsers(count: usize, name: &str, opts: &Opts) -> QueryResult {
-    let (name, stat) = get_browser_stat(name, opts.mobile_to_desktop)
+    let (name, version_list) = get_browser_stat(name, opts.mobile_to_desktop)
         .ok_or_else(|| Error::BrowserNotFound(name.to_string()))?;
     let count = count_filter_versions(name, opts.mobile_to_desktop, count);
 
-    let distribs = stat
-        .version_list
+    let distribs = version_list
         .iter()
-        .filter(|version| version.release_date.is_some())
+        .filter(|version| version.released)
         .rev()
         .take(count)
-        .map(|version| Distrib::new(name, version.version))
+        .map(|version| Distrib::new(name, version.version.as_str()))
         .collect();
     Ok(distribs)
 }

--- a/src/queries/last_n_x_major_browsers.rs
+++ b/src/queries/last_n_x_major_browsers.rs
@@ -3,14 +3,13 @@ use crate::{data::caniuse::get_browser_stat, error::Error, opts::Opts};
 use itertools::Itertools;
 
 pub(super) fn last_n_x_major_browsers(count: usize, name: &str, opts: &Opts) -> QueryResult {
-    let (name, stat) = get_browser_stat(name, opts.mobile_to_desktop)
+    let (name, version_list) = get_browser_stat(name, opts.mobile_to_desktop)
         .ok_or_else(|| Error::BrowserNotFound(name.to_string()))?;
     let count = count_filter_versions(name, opts.mobile_to_desktop, count);
-    let minimum = stat
-        .version_list
+    let minimum = version_list
         .iter()
-        .filter(|version| version.release_date.is_some())
-        .map(|version| version.version)
+        .filter(|version| version.released)
+        .map(|version| version.version.as_str())
         .rev()
         .map(|version| version.split('.').next().unwrap())
         .dedup()
@@ -18,11 +17,10 @@ pub(super) fn last_n_x_major_browsers(count: usize, name: &str, opts: &Opts) -> 
         .and_then(|minimum| minimum.parse().ok())
         .unwrap_or(0);
 
-    let distribs = stat
-        .version_list
+    let distribs = version_list
         .iter()
-        .filter(|version| version.release_date.is_some())
-        .map(|version| version.version)
+        .filter(|version| version.released)
+        .map(|version| version.version.as_str())
         .filter(move |version| version.split('.').next().unwrap().parse().unwrap_or(0) >= minimum)
         .rev()
         .map(move |version| Distrib::new(name, version))

--- a/src/queries/maintained_node.rs
+++ b/src/queries/maintained_node.rs
@@ -1,18 +1,15 @@
 use super::{Distrib, QueryResult};
-use crate::data::node::{NODE_VERSIONS, RELEASE_SCHEDULE};
+use crate::data::node;
 use chrono::Local;
 
 pub(super) fn maintained_node() -> QueryResult {
     let now = Local::now().naive_local();
-
-    let versions = RELEASE_SCHEDULE
-        .iter()
-        .filter(|(_, (start, end))| *start < now && now < *end)
-        .filter_map(|(version, _)| {
-            NODE_VERSIONS
+    let versions = node::release_schedule(now.date())
+        .filter_map(|version| {
+            node::versions()
                 .iter()
                 .rev()
-                .find(|v| v.split('.').next().unwrap() == *version)
+                .find(|v| v.split('.').next().unwrap() == version)
         })
         .map(|version| Distrib::new("node", *version))
         .collect();

--- a/src/queries/mod.rs
+++ b/src/queries/mod.rs
@@ -234,7 +234,7 @@ pub fn count_filter_versions(name: &str, mobile_to_desktop: bool, count: usize) 
                     .iter()
                     .filter(|version| version.released)
                     .map(|version| version.version.as_str())
-                    .last()
+                    .next_back()
                     .unwrap()
                     .parse::<f32>()
                     .unwrap();

--- a/src/queries/mod.rs
+++ b/src/queries/mod.rs
@@ -231,10 +231,9 @@ pub fn count_filter_versions(name: &str, mobile_to_desktop: bool, count: usize) 
                 let last_released = &caniuse::get_browser_stat("android", mobile_to_desktop)
                     .unwrap()
                     .1
-                    .version_list
                     .iter()
-                    .filter(|version| version.release_date.is_some())
-                    .map(|version| version.version)
+                    .filter(|version| version.released)
+                    .map(|version| version.version.as_str())
                     .last()
                     .unwrap()
                     .parse::<f32>()
@@ -246,11 +245,11 @@ pub fn count_filter_versions(name: &str, mobile_to_desktop: bool, count: usize) 
             let lastest = caniuse::get_browser_stat("android", mobile_to_desktop)
                 .unwrap()
                 .1
-                .version_list
                 .last()
                 .unwrap();
-            (lastest.version.parse::<Version>().unwrap().major() - caniuse::OP_MOB_BLINK_FIRST + 1)
-                as usize
+            (lastest.version.as_str().parse::<Version>().unwrap().major()
+                - caniuse::OP_MOB_BLINK_FIRST
+                + 1) as usize
         }
         _ => return count,
     };

--- a/src/queries/node_accurate.rs
+++ b/src/queries/node_accurate.rs
@@ -1,8 +1,8 @@
 use super::{Distrib, QueryResult};
-use crate::{data::node::NODE_VERSIONS, error::Error, opts::Opts};
+use crate::{data::node, error::Error, opts::Opts};
 
 pub(super) fn node_accurate(version: &str, opts: &Opts) -> QueryResult {
-    let distribs = NODE_VERSIONS
+    let distribs = node::versions()
         .iter()
         .rev()
         .find(|v| v.split('.').zip(version.split('.')).all(|(a, b)| a == b))

--- a/src/queries/node_bounded_range.rs
+++ b/src/queries/node_bounded_range.rs
@@ -1,9 +1,9 @@
 use super::{Distrib, QueryResult};
-use crate::{data::node::NODE_VERSIONS, semver::loose_compare};
+use crate::{data::node, semver::loose_compare};
 use std::cmp::Ordering;
 
 pub(super) fn node_bounded_range(from: &str, to: &str) -> QueryResult {
-    let distribs = NODE_VERSIONS
+    let distribs = node::versions()
         .iter()
         .filter(|version| {
             matches!(

--- a/src/queries/node_unbounded_range.rs
+++ b/src/queries/node_unbounded_range.rs
@@ -1,9 +1,9 @@
 use super::{Distrib, QueryResult};
-use crate::{data::node::NODE_VERSIONS, parser::Comparator, semver::compare};
+use crate::{data::node, parser::Comparator, semver::compare};
 use std::cmp::Ordering;
 
 pub(super) fn node_unbounded_range(comparator: Comparator, version: &str) -> QueryResult {
-    let distribs = NODE_VERSIONS
+    let distribs = node::versions()
         .iter()
         .filter(|v| {
             let ord = compare(v, version);

--- a/src/queries/percentage.rs
+++ b/src/queries/percentage.rs
@@ -5,7 +5,7 @@ pub(super) fn percentage(comparator: Comparator, popularity: f32) -> QueryResult
     let distribs = CANIUSE_BROWSERS
         .iter()
         .flat_map(|(name, stat)| {
-            stat.version_list
+            stat.version_list()
                 .iter()
                 .filter(|version| {
                     let usage = version.global_usage;
@@ -16,7 +16,7 @@ pub(super) fn percentage(comparator: Comparator, popularity: f32) -> QueryResult
                         Comparator::LessOrEqual => usage <= popularity,
                     }
                 })
-                .map(|version| Distrib::new(name, version.version))
+                .map(|version| Distrib::new(name.as_str(), version.version.as_str()))
         })
         .collect();
     Ok(distribs)

--- a/src/queries/percentage_by_region.rs
+++ b/src/queries/percentage_by_region.rs
@@ -21,7 +21,7 @@ pub(super) fn percentage_by_region(
                 Comparator::GreaterOrEqual => *usage >= popularity,
                 Comparator::LessOrEqual => *usage <= popularity,
             })
-            .map(|(name, version, _)| Distrib::new(name, *version))
+            .map(|(name, version, _)| Distrib::new(name, version))
             .collect();
         Ok(distribs)
     } else {

--- a/src/queries/since.rs
+++ b/src/queries/since.rs
@@ -5,7 +5,7 @@ use chrono::{LocalResult, TimeZone, Utc};
 pub(super) fn since(year: i32, month: u32, day: u32, opts: &Opts) -> QueryResult {
     let time = match Utc.with_ymd_and_hms(year, month, day, 0, 0, 0) {
         LocalResult::Single(date) => date.timestamp(),
-        _ => return Err(Error::InvalidDate(format!("{}-{}-{}", year, month, day))),
+        _ => return Err(Error::InvalidDate(format!("{year}-{month}-{day}"))),
     };
 
     let distribs = caniuse::iter_browser_stat(opts.mobile_to_desktop)

--- a/src/queries/supports.rs
+++ b/src/queries/supports.rs
@@ -30,7 +30,7 @@ pub(super) fn supports(name: &str, kind: Option<SupportKind>, opts: &Opts) -> Qu
                         .filter(|version| version.released)
                         .filter_map(|latest_version| versions.get(latest_version.version.as_str()))
                         .last()
-                        .is_some_and(|flags| is_supported(*flags, include_partial));
+                        .is_some_and(|flags| is_supported(flags, include_partial));
                 browser_stat
                     .iter()
                     .filter_map(move |VersionDetail { version, .. }| {
@@ -43,7 +43,7 @@ pub(super) fn supports(name: &str, kind: Option<SupportKind>, opts: &Opts) -> Qu
                                 _ => None,
                             })
                             .and_then(|flags| {
-                                is_supported(*flags, include_partial).then_some(version)
+                                is_supported(flags, include_partial).then_some(version)
                             })
                     })
                     .map(move |version| Distrib::new(name, version.as_str()))

--- a/src/queries/supports.rs
+++ b/src/queries/supports.rs
@@ -26,29 +26,27 @@ pub(super) fn supports(name: &str, kind: Option<SupportKind>, opts: &Opts) -> Qu
                     .flatten();
                 let check_desktop = desktop_name.is_some()
                     && browser_stat
-                        .version_list
                         .iter()
-                        .filter(|version| version.release_date.is_some())
-                        .filter_map(|latest_version| versions.get(latest_version.version))
+                        .filter(|version| version.released)
+                        .filter_map(|latest_version| versions.get(latest_version.version.as_str()))
                         .last()
                         .is_some_and(|flags| is_supported(*flags, include_partial));
                 browser_stat
-                    .version_list
                     .iter()
                     .filter_map(move |VersionDetail { version, .. }| {
                         versions
-                            .get(version)
+                            .get(version.as_str())
                             .or_else(|| match desktop_name {
                                 Some(desktop_name) if check_desktop => feature
                                     .get(desktop_name)
-                                    .and_then(|versions| versions.get(version)),
+                                    .and_then(|versions| versions.get(version.as_str())),
                                 _ => None,
                             })
                             .and_then(|flags| {
                                 is_supported(*flags, include_partial).then_some(version)
                             })
                     })
-                    .map(move |version| Distrib::new(name, *version))
+                    .map(move |version| Distrib::new(name, version.as_str()))
             })
             .collect();
         Ok(distribs)

--- a/src/queries/supports.rs
+++ b/src/queries/supports.rs
@@ -29,7 +29,7 @@ pub(super) fn supports(name: &str, kind: Option<SupportKind>, opts: &Opts) -> Qu
                         .iter()
                         .filter(|version| version.released)
                         .filter_map(|latest_version| versions.get(latest_version.version.as_str()))
-                        .last()
+                        .next_back()
                         .is_some_and(|flags| is_supported(flags, include_partial));
                 browser_stat
                     .iter()

--- a/src/queries/unreleased_browsers.rs
+++ b/src/queries/unreleased_browsers.rs
@@ -1,18 +1,13 @@
 use super::{Distrib, QueryResult};
-use crate::{
-    data::caniuse::{get_browser_stat, CANIUSE_BROWSERS},
-    opts::Opts,
-};
+use crate::{data::caniuse, opts::Opts};
 
 pub(super) fn unreleased_browsers(opts: &Opts) -> QueryResult {
-    let distribs = CANIUSE_BROWSERS
-        .keys()
-        .filter_map(|name| get_browser_stat(name, opts.mobile_to_desktop))
-        .flat_map(|(name, stat)| {
-            stat.version_list
+    let distribs = caniuse::iter_browser_stat(opts.mobile_to_desktop)
+        .flat_map(|(name, version_list)| {
+            version_list
                 .iter()
-                .filter(|version| version.release_date.is_none())
-                .map(|version| Distrib::new(name, version.version))
+                .filter(|version| !version.released)
+                .map(move |version| Distrib::new(name, version.version.as_str()))
         })
         .collect();
     Ok(distribs)

--- a/src/queries/unreleased_x_browsers.rs
+++ b/src/queries/unreleased_x_browsers.rs
@@ -2,13 +2,12 @@ use super::{Distrib, QueryResult};
 use crate::{data::caniuse::get_browser_stat, error::Error, opts::Opts};
 
 pub(super) fn unreleased_x_browsers(name: &str, opts: &Opts) -> QueryResult {
-    let (name, stat) = get_browser_stat(name, opts.mobile_to_desktop)
+    let (name, version_list) = get_browser_stat(name, opts.mobile_to_desktop)
         .ok_or_else(|| Error::BrowserNotFound(name.to_string()))?;
-    let distribs = stat
-        .version_list
+    let distribs = version_list
         .iter()
-        .filter(|version| version.release_date.is_none())
-        .map(|version| Distrib::new(name, version.version))
+        .filter(|version| !version.released)
+        .map(|version| Distrib::new(name, version.version.as_str()))
         .collect();
     Ok(distribs)
 }

--- a/src/queries/years.rs
+++ b/src/queries/years.rs
@@ -1,9 +1,5 @@
 use super::{Distrib, QueryResult};
-use crate::{
-    data::caniuse::{get_browser_stat, CANIUSE_BROWSERS},
-    error::Error,
-    opts::Opts,
-};
+use crate::{data::caniuse, error::Error, opts::Opts};
 use chrono::{Duration, Utc};
 
 const ONE_YEAR_IN_SECONDS: f64 = 365.259641 * 24.0 * 60.0 * 60.0;
@@ -13,14 +9,12 @@ pub(super) fn years(count: f64, opts: &Opts) -> QueryResult {
         Duration::try_seconds((count * ONE_YEAR_IN_SECONDS) as i64).ok_or(Error::YearOverflow)?;
     let time = (Utc::now() - duration).timestamp();
 
-    let distribs = CANIUSE_BROWSERS
-        .keys()
-        .filter_map(|name| get_browser_stat(name, opts.mobile_to_desktop))
-        .flat_map(|(name, stat)| {
-            stat.version_list
+    let distribs = caniuse::iter_browser_stat(opts.mobile_to_desktop)
+        .flat_map(|(name, version_list)| {
+            version_list
                 .iter()
-                .filter(|version| matches!(version.release_date, Some(date) if date >= time))
-                .map(|version| Distrib::new(name, version.version))
+                .filter(|version| version.released && version.release_date >= time)
+                .map(move |version| Distrib::new(name, version.version.as_str()))
         })
         .collect();
     Ok(distribs)

--- a/src/test.rs
+++ b/src/test.rs
@@ -36,6 +36,7 @@ pub fn run_compare(query: &str, opts: &Opts, cwd: Option<&Path>) {
         .map(|d| d.to_string())
         .collect::<Vec<_>>();
 
+    assert_eq!(expected.len(), actual.len());
     assert_eq!(expected, actual);
 }
 

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,4 +1,4 @@
-use browserslist::{Opts, resolve};
+use browserslist::{resolve, Opts};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]


### PR DESCRIPTION
This PR is not yet completed. Its goal is to make `browserslist-rs` data completely static to reduce resident memory and binary size.

This is a big refactor, so I opened a draft to get early feedback on whether this is a good direction.

Current implemented
1. use static slice instead of lazy + cell
2. more use of binary search for `.get()`
3. introduction `PooledStr` to reduce data size (reduce the size of relocation section and compress type from u64\*2 to u32\*2 )

The refactor of `features` and `region` is not yet complete. The data size of these two is quite large, and implement them as code will cause serious compile time regression.
I expected to implement it using `include_bytes!` and `Aligned` trick (like https://jack.wrenn.fyi/blog/include-transmute/), which would look a bit ugly, but have good compile time and runtime performance.
